### PR TITLE
Uncomment High DPI support code.

### DIFF
--- a/src/Wnmp/app.manifest
+++ b/src/Wnmp/app.manifest
@@ -49,13 +49,11 @@
        DPIs. Windows Presentation Foundation (WPF) applications are automatically DPI-aware and do not need 
        to opt in. Windows Forms applications targeting .NET Framework 4.6 that opt into this setting, should 
        also set the 'EnableWindowsFormsHighDpiAutoResizing' setting to 'true' in their app.config. -->
-  <!--
   <application xmlns="urn:schemas-microsoft-com:asm.v3">
     <windowsSettings>
       <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true</dpiAware>
     </windowsSettings>
   </application>
-  -->
 
   <!-- Enable themes for Windows common controls and dialogs (Windows XP and later) -->
   <!--


### PR DESCRIPTION
Why High DPI support is disabled? Any compatibility issues?

I test on my computer with windows 11, it just works.

![Before](https://user-images.githubusercontent.com/20637056/189795368-7f77e4b4-0fa6-4f05-b64c-21ded14ceafa.png)

![After](https://user-images.githubusercontent.com/20637056/189795439-faa9383a-9384-4578-9e9e-16a990d2bfa2.png)
